### PR TITLE
No lens appear until we leave and reenter into the thumb.

### DIFF
--- a/src/ngx-image-zoom.component.ts
+++ b/src/ngx-image-zoom.component.ts
@@ -201,6 +201,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
         this.calculateRatioAndOffset();
         if (this.thumbImageLoaded && this.fullImageLoaded) {
             this.calculateImageAndLensPosition();
+            this.display = 'block';
             this.isReady = true;
         }
     }


### PR DESCRIPTION
fix : When large full image is lately loaded (into a pop-up), no lens will appear until we leave and reenter into the thumbnail.

Due to `isReady === false` when we pass into zoomOn function and `display = 'block'` is never set until mouseLeave and mouseEnter again.