### PR TITLE
Adding support for Angular Universal

### DIFF
--- a/src/ngx-image-zoom.component.ts
+++ b/src/ngx-image-zoom.component.ts
@@ -64,7 +64,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
     private latestMouseTop: number;
     private scrollParent: Element;
 
-    constructor(private renderer: Renderer2) {
+    constructor(private renderer: Renderer2, private elRef: ElementRef) {
     }
 
     @Input('thumbImage')
@@ -181,7 +181,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
     }
 
     ngAfterViewInit(): void {
-        this.scrollParent = document.querySelector(this.scrollParentSelector);
+        this.scrollParent = this.elRef.nativeElement.parentElement;
     }
 
     /**


### PR DESCRIPTION
Now it works fine in Angular Universal. Beside, it works fine with parent scrolling view. No need to `scrollParentSelector` property anymore.