### PR TITLE
Using binding in 'src' attribute instead of interpolation to support SafeUrl | SafeResourceUrl

### DIFF
--- a/src/ngx-image-zoom.component.html
+++ b/src/ngx-image-zoom.component.html
@@ -1,7 +1,7 @@
 <div #zoomContainer class="ngxImageZoomContainer"
      [style.width.px]="this.thumbWidth" [style.height.px]="this.thumbHeight">
 
-    <img #imageThumbnail class="ngxImageZoomThumbnail" src="{{ thumbImage }}" width="100%" height="100%"
+    <img #imageThumbnail class="ngxImageZoomThumbnail" [src]="thumbImage" width="100%" height="100%"
          (load)="onThumbImageLoaded()"/>
 
     <div [ngClass]="{'ngxImageZoomFullContainer': true, 'ngxImageZoomLensEnabled': this.enableLens}"
@@ -12,7 +12,7 @@
          [style.height.px]="this.lensHeight"
          [style.border-radius.px]="this.lensBorderRadius"
     >
-        <img #fullSizeImage class="ngxImageZoomFull" src="{{ fullImage }}"
+        <img #fullSizeImage class="ngxImageZoomFull" [src]="fullImage"
              (load)="onFullImageLoaded()"
              [style.display]="this.display"
              [style.top.px]="this.fullImageTop"


### PR DESCRIPTION
Hey, thanks for this lib, its really useful.
I know this PR is a duplicate of https://github.com/wittlock/ngx-image-zoom/pull/13,
but I happen to need this little change as soon as possible.

I'm currently using the branch **feature/base64** of my fork, to which I've pushed the dist/ dir in order to consume it from my package.json as so:
`
{
...,
"ngx-image-zoom": "https://github.com/tomsjer/ngx-image-zoom.git#feature/base64",
...
}
`
Not so good... anyway, I've tested it with [src]="data:image/jpg;base64,/..." and [src]="http://placehold.it/200/200", both working ok.
Cheers.
