### PR TITLE
scrollParentSelector optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ lensHeight | 100 | Height of the lens, if enabled.
 circularLens | false | Make the lens circular instead of square. This will only look good if width and height are equal.
 minZoomRatio | *baseRatio* | Lower limit on how much zoom can be applied with scrollZoom enabled. See below for details.
 maxZoomRatio | 2 | Upper limit on how much zoom can be applied with scrollZoom enabled. See below for details.
+scrollParentSelector | *none* | Selector of parent scrolling view as string. This avoid zoom gap with cursor when the scrolling view is not the main window. Example : '#scrolling-frame'
 isInsideStaticContainer | false | Set to `true` if the thumbnail is inside a container, to which `position: static` is applied (e.g. a modal window). This is required to avoid zoom position being calculated incorrectly.
 
 ### Zoom modes

--- a/src/ngx-image-zoom.component.ts
+++ b/src/ngx-image-zoom.component.ts
@@ -45,6 +45,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
     private enableScrollZoom = false;
     private scrollStepSize = 0.1;
     private circularLens = false;
+    private scrollParentSelector: string;
 
     private baseRatio: number;
     private minZoomRatio;
@@ -135,6 +136,11 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
         this.enableScrollZoom = Boolean(enable);
     }
 
+    @Input('scrollParentSelector')
+    public set setScrollParentSelector(selector: string) {
+        this.scrollParentSelector = selector;
+    }
+
     @Input('isInsideStaticContainer')
     public set setisInsideStaticContainer(isInStatic: boolean) {
         this.isInsideStaticContainer = isInStatic;
@@ -181,7 +187,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
     }
 
     ngAfterViewInit(): void {
-        this.scrollParent = this.elRef.nativeElement.parentElement;
+        this.scrollParent = this.scrollParentSelector ? document.querySelector(this.scrollParentSelector) : this.elRef.nativeElement.parentElement;
     }
 
     /**


### PR DESCRIPTION
Hello,

I think it would be better to define this property as optional, because sometimes, you will want to use the parent of parent or something else.

I just ran into the case where the ngx-image-zoom is inside a nested and collapsable div inside a modal. When the div is opened, the scrollbar appears and the zoom position is wrong when I scroll down.

Good job though!