### PR TITLE
not reacting to mouse wheel events when not in zoom mode

### DIFF
--- a/src/ngx-image-zoom.component.ts
+++ b/src/ngx-image-zoom.component.ts
@@ -224,6 +224,8 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, AfterViewInit {
      * Mouse wheel event
      */
     private onMouseWheel(event: any) {
+        if(!this.zoomingEnabled) return;
+        
         event = window.event || event; // old IE
         const direction = Math.max(Math.min((event.wheelDelta || -event.detail), 1), -1);
         if (direction > 0) {


### PR DESCRIPTION
When setting the zoomMode to 'click' and enableScrollZoom to true -> the component registers event listeners onMouseWeel and prevents page scrolling even if the component is not in zoomMode. It is confusing for the user that is trying to scroll the page and nothing happens -- page is not scrolled and there is no zoom since he/she never clicked on the image.