### PR TITLE
upgrade dependencies to support angular 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
         "url": "https://www.github.com/wittlock/ngx-image-zoom/issues"
     },
     "devDependencies": {
-        "@angular/common": "^5.0.0",
-        "@angular/compiler": "^5.0.0",
-        "@angular/compiler-cli": "^5.0.0",
-        "@angular/core": "^5.0.0",
-        "@angular/platform-browser": "^5.0.0",
-        "@angular/platform-browser-dynamic": "^5.0.0",
+        "@angular/common": "^6.0.0",
+        "@angular/compiler": "^6.0.0",
+        "@angular/compiler-cli": "^6.0.0",
+        "@angular/core": "^6.0.0",
+        "@angular/platform-browser": "^6.0.0",
+        "@angular/platform-browser-dynamic": "^6.0.0",
         "@compodoc/compodoc": "^1.0.0-beta.10",
         "@types/jasmine": "2.5.53",
         "@types/node": "~6.0.60",
@@ -70,11 +70,11 @@
         "systemjs": "^0.20.12",
         "ts-node": "~3.2.0",
         "tslint": "~5.7.0",
-        "typescript": "~2.4.2",
+        "typescript": "~2.7.2",
         "zone.js": "^0.8.14"
     },
     "peerDependencies": {
-        "@angular/core": "^5.2.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@angular/core": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "rxjs": "^5.5.0 || ^6.0.0"
     },
     "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export * from './ngx-image-zoom.component';
     ]
 })
 export class NgxImageZoomModule {
-    static forRoot(): ModuleWithProviders {
+    static forRoot(): ModuleWithProviders<NgxImageZoomModule> {
         return {
             ngModule: NgxImageZoomModule,
         };


### PR DESCRIPTION
Angular version 9 deprecates use of ModuleWithProviders without an explicitly generic type, where the generic type refers to the type of the NgModule. In a future version of Angular, the generic will no longer be optional.

drop support for angular 5.
add support for angular 9.

Resolves https://github.com/wittlock/ngx-image-zoom/issues/50

Ref: https://next.angular.io/guide/deprecations#moduleWithProviders