### PR TITLE
Support on ChangeDetection-Strategy OnPush

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@zeitdev/ngx-image-zoom",
+    "name": "@zeit-dev/ngx-image-zoom",
     "version": "0.6.1",
     "scripts": {
         "build": "ng build ngx-image-zoom",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "ngx-image-zoom",
-    "version": "0.6.0",
+    "name": "@zeitdev/ngx-image-zoom",
+    "version": "0.6.1",
     "scripts": {
         "build": "ng build ngx-image-zoom",
         "build:release": "ng build ngx-image-zoom --prod",

--- a/src/lib/ngx-image-zoom.component.ts
+++ b/src/lib/ngx-image-zoom.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
+import { ChangeDetectorRef } from '@angular/core';
 
 export interface Coord {
     x: number;
@@ -64,7 +65,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, OnDestroy {
 
     private eventListeners: (() => void)[] = [];
 
-    constructor(private renderer: Renderer2) {
+    constructor(private renderer: Renderer2, private changeDetectorRef: ChangeDetectorRef) {
     }
 
     @Input('thumbImage')
@@ -367,6 +368,7 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, OnDestroy {
     private zoomOff() {
         this.zoomingEnabled = false;
         this.display = 'none';
+        this.changeDetectorRef.markForCheck();
     }
 
     private calculateZoomPosition(event: MouseEvent) {
@@ -389,6 +391,8 @@ export class NgxImageZoomComponent implements OnInit, OnChanges, OnDestroy {
 
         this.fullImageLeft = (this.latestMouseLeft * -this.xRatio) - lensLeftMod;
         this.fullImageTop = (this.latestMouseTop * -this.yRatio) - lensTopMod;
+
+        this.changeDetectorRef.markForCheck();
     }
 
     private calculateRatioAndOffset() {


### PR DESCRIPTION
Could also possibly fix https://github.com/wittlock/ngx-image-zoom/issues/36

We have ngx-image-zoom embedded in an OnPush component and apparently this is not supported (at least it stopped working with Ivy / NG9).

This is a work in progress, open for discussion. I did not dive deep into the code, just needed a quick fix for our app.

I published this branch on NPM as `@zeit-dev/ngx-image-zoom`, v0.6.1 if anybody would like to try.
Cheers
Marian

PS: To replace the original `ngx-image-zoom` with `@zeit-dev/ngx-image-zoom` don't forget to remap the path in `tsconfig.json`:

```
{
  "compilerOptions": {
    ...,
    "paths": {
      "ngx-image-zoom": ["node_modules/@zeit-dev/ngx-image-zoom"]
    }
  },
  ...
}
```